### PR TITLE
[TAC] Remove empty cookie key from getCookiesList

### DIFF
--- a/tac_services/libraries/tac_additions/tac_helpers.js
+++ b/tac_services/libraries/tac_additions/tac_helpers.js
@@ -19,6 +19,9 @@ var TacHelpers = {
 
         for( var i in list ){
             var split = list[i].split('=');
+            if (split[0] === '') {
+                continue;   
+            }
             cookies[split[0]] = split['1'];
         }
 


### PR DESCRIPTION
This could prevent errors when the checked key is faulty and comparison is not strict.