### PR TITLE
Dev/fix custom text and url in banner

### DIFF
--- a/tac_services/libraries/tac_additions/tac_init.js
+++ b/tac_services/libraries/tac_additions/tac_init.js
@@ -138,6 +138,7 @@ var TacEventsHandlers = {
           "removeCredit": true, /* supprimer le lien vers la source ? */
           "orientation": settings.orientation,
           "mandatory": settings.mandatory,
+          "cookiesDuration": settings.cookies_duration, /*Durée de conservation des cookies */
         });
         // If the disclaimer text is customized by the user, we replace it when TAC is loaded
         if(settings.custom_disclaimer){

--- a/tac_services/libraries/tarteaucitron/css/tarteaucitron.css
+++ b/tac_services/libraries/tarteaucitron/css/tarteaucitron.css
@@ -630,6 +630,15 @@ span#tarteaucitronDisclaimerAlert {
     padding: 5px 10px;
 }
 
+#tarteaucitronAlertBig #tarteaucitronPrivacyUrl{
+    display: block;
+    margin: 0px auto 10px;
+}
+
+#tarteaucitronAlertBig #tarteaucitronAlertBigBtnWrapper{
+    text-align: center;
+}
+
 #tarteaucitronPercentage {
     background: #0A0!important;
     box-shadow: 0 0 2px #fff, 0 1px 2px #555;

--- a/tac_services/libraries/tarteaucitron/tarteaucitron.js
+++ b/tac_services/libraries/tarteaucitron/tarteaucitron.js
@@ -232,7 +232,7 @@ var tarteaucitron = {
                 "useExternalJs": false,
                 "mandatory": true,
                 "closePopup": false,
-                "cookiesDuration": 365 /* Adimeo custom cookies duration */
+                "cookiesDuration": 365 /* Adimeo addition */
             },
             params = tarteaucitron.parameters;
 
@@ -404,13 +404,13 @@ var tarteaucitron = {
                         html += '   </button>';
                     }
 
-                    html += '   <div id="tarteaucitronAlertBigBtnWrapper">';
+                    html += '   <div id="tarteaucitronAlertBigBtnWrapper">'; /* Adimeo addition : buttons in wrapper */
                     html += '   <button type="button" id="tarteaucitronPersonalize">';
                     html += '       ' + tarteaucitron.lang.personalize;
                     html += '   </button>';
 
                     //html += '   </span>';
-                    html += '</div>';
+                    html += '</div>';/* Adimeo addition : buttons in wrapper */
                     html += '</div>';
                 } else {
                     html += '<div id="tarteaucitronAlertBig" class="tarteaucitronAlertBig' + orientation + '">';
@@ -425,31 +425,30 @@ var tarteaucitron = {
 
                     html += '   </span>';
 
+                    /* Adimeo addition : privacy link before other buttons */
                     if (tarteaucitron.parameters.privacyUrl !== "") {
                         html += '   <button type="button" id="tarteaucitronPrivacyUrl">';
                         html += '       ' + tarteaucitron.lang.privacyUrl;
                         html += '   </button>';
                     }
 
-                    html += '   <div id="tarteaucitronAlertBigBtnWrapper">';
+                    html += '   <div id="tarteaucitronAlertBigBtnWrapper">';/* Adimeo addition : buttons in wrapper */
                     html += '   <button type="button" class="tarteaucitronCTAButton tarteaucitronAllow" id="tarteaucitronPersonalize2">';
                     html += '       <span class="tarteaucitronCheck"></span> ' + tarteaucitron.lang.acceptAll;
-
-
                     html += '   </button>';
+
                     if (tarteaucitron.parameters.DenyAllCta) {
                         html += '   <button type="button" class="tarteaucitronCTAButton tarteaucitronDeny" id="tarteaucitronAllDenied2">';
                         html += '       <span class="tarteaucitronCross"></span> ' + tarteaucitron.lang.denyAll;
                         html += '   </button>';
                         //html += '   <br/><br/>';
-
                     }
                     html += '   <button type="button" id="tarteaucitronCloseAlert">';
                     html += '       ' + tarteaucitron.lang.personalize;
                     html += '   </button>';
 
                     //html += '   </span>';
-                    html += '</div>';
+                    html += '</div>';/* Adimeo addition : buttons in wrapper */
                     html += '</div>';
                     html += '<div id="tarteaucitronPercentage"></div>';
                 }
@@ -1411,7 +1410,7 @@ var tarteaucitron = {
         "create": function (key, status) {
             "use strict";
 
-            //Adimeo custom cookies duration
+            //Adimeo addition
             tarteaucitronForceExpire = tarteaucitron.parameters.cookiesDuration;
 
             if (tarteaucitronForceExpire !== '') {

--- a/tac_services/libraries/tarteaucitron/tarteaucitron.js
+++ b/tac_services/libraries/tarteaucitron/tarteaucitron.js
@@ -396,10 +396,6 @@ var tarteaucitron = {
                     html += '   <span id="tarteaucitronDisclaimerAlert">';
                     html += '       ' + tarteaucitron.lang.alertBigPrivacy;
                     html += '   </span>';
-                    //html += '   <span class="tarteaucitronAlertBigBtnWrapper">';
-                    html += '   <button type="button" id="tarteaucitronPersonalize">';
-                    html += '       ' + tarteaucitron.lang.personalize;
-                    html += '   </button>';
 
                     if (tarteaucitron.parameters.privacyUrl !== "") {
                         html += '   <button type="button" id="tarteaucitronPrivacyUrl">';
@@ -407,8 +403,13 @@ var tarteaucitron = {
                         html += '   </button>';
                     }
 
+                    html += '   <div id="tarteaucitronAlertBigBtnWrapper">';
+                    html += '   <button type="button" id="tarteaucitronPersonalize">';
+                    html += '       ' + tarteaucitron.lang.personalize;
+                    html += '   </button>';
+
                     //html += '   </span>';
-                    //html += '</div>';
+                    html += '</div>';
                     html += '</div>';
                 } else {
                     html += '<div id="tarteaucitronAlertBig" class="tarteaucitronAlertBig' + orientation + '">';
@@ -422,22 +423,6 @@ var tarteaucitron = {
                     }
 
                     html += '   </span>';
-                    //html += '   <span class="tarteaucitronAlertBigBtnWrapper">';
-                    html += '   <button type="button" class="tarteaucitronCTAButton tarteaucitronAllow" id="tarteaucitronPersonalize2">';
-                    html += '       <span class="tarteaucitronCheck"></span> ' + tarteaucitron.lang.acceptAll;
-                    html += '   </button>';
-
-
-                    if (tarteaucitron.parameters.DenyAllCta) {
-                                    html += '   <button type="button" class="tarteaucitronCTAButton tarteaucitronDeny" id="tarteaucitronAllDenied2">';
-                                    html += '       <span class="tarteaucitronCross"></span> ' + tarteaucitron.lang.denyAll;
-                                    html += '   </button>';
-                                    //html += '   <br/><br/>';
-                    }
-
-                    html += '   <button type="button" id="tarteaucitronCloseAlert">';
-                    html += '       ' + tarteaucitron.lang.personalize;
-                    html += '   </button>';
 
                     if (tarteaucitron.parameters.privacyUrl !== "") {
                         html += '   <button type="button" id="tarteaucitronPrivacyUrl">';
@@ -445,8 +430,25 @@ var tarteaucitron = {
                         html += '   </button>';
                     }
 
+                    html += '   <div id="tarteaucitronAlertBigBtnWrapper">';
+                    html += '   <button type="button" class="tarteaucitronCTAButton tarteaucitronAllow" id="tarteaucitronPersonalize2">';
+                    html += '       <span class="tarteaucitronCheck"></span> ' + tarteaucitron.lang.acceptAll;
+
+
+                    html += '   </button>';
+                    if (tarteaucitron.parameters.DenyAllCta) {
+                        html += '   <button type="button" class="tarteaucitronCTAButton tarteaucitronDeny" id="tarteaucitronAllDenied2">';
+                        html += '       <span class="tarteaucitronCross"></span> ' + tarteaucitron.lang.denyAll;
+                        html += '   </button>';
+                        //html += '   <br/><br/>';
+
+                    }
+                    html += '   <button type="button" id="tarteaucitronCloseAlert">';
+                    html += '       ' + tarteaucitron.lang.personalize;
+                    html += '   </button>';
+
                     //html += '   </span>';
-                    //html += '</div>';
+                    html += '</div>';
                     html += '</div>';
                     html += '<div id="tarteaucitronPercentage"></div>';
                 }

--- a/tac_services/libraries/tarteaucitron/tarteaucitron.js
+++ b/tac_services/libraries/tarteaucitron/tarteaucitron.js
@@ -231,7 +231,8 @@ var tarteaucitron = {
                 "useExternalCss": false,
                 "useExternalJs": false,
                 "mandatory": true,
-                "closePopup": false
+                "closePopup": false,
+                "cookiesDuration": 365 /* Adimeo custom cookies duration */
             },
             params = tarteaucitron.parameters;
 
@@ -1409,6 +1410,9 @@ var tarteaucitron = {
         "owner": {},
         "create": function (key, status) {
             "use strict";
+
+            //Adimeo custom cookies duration
+            tarteaucitronForceExpire = tarteaucitron.parameters.cookiesDuration;
 
             if (tarteaucitronForceExpire !== '') {
                 // The number of day(s)/hour(s) can't be higher than 1 year

--- a/tac_services/src/Form/TacSettingsForm.php
+++ b/tac_services/src/Form/TacSettingsForm.php
@@ -189,14 +189,6 @@ class TacSettingsForm extends FormBase {
       '#description'   => t('Afficher le message a propos des cookies obligatoires ?'),
     ];
 
-    $default = $this->config->getAlertLabel();
-    $form[$this->config::ALERT_LABEL] = [
-      '#type'          => 'text_format',
-      '#title'         => t('Message de l\'encart d\'alert'),
-      '#default_value' => $default ? $default['value'] : '',
-      '#format'        => $default ? $default['format'] : 'full_html',
-    ];
-
     $form['submit'] = [
       '#type'        => 'submit',
       '#value'       => t('Save'),

--- a/tac_services/src/Form/TacSettingsForm.php
+++ b/tac_services/src/Form/TacSettingsForm.php
@@ -80,18 +80,18 @@ class TacSettingsForm extends FormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $defaultValues = $this->config->getAllValues();
 
-    $form[$this->config::PRIVACY_URL] = [
+      $form[$this->config::CUSTOM_DISCLAIMER] = [
+          '#type'          => 'textarea',
+          '#title'         => t('Texte de déclaration des cookies'),
+          '#default_value' => $defaultValues[$this->config::CUSTOM_DISCLAIMER],
+          '#description' => t('Vous pouvez définir le texte invitant les visiteurs à accepter les cookies. Laisser vide pour utiliser le texte par défaut.'),
+      ];
+
+      $form[$this->config::PRIVACY_URL] = [
       '#type'          => 'textfield',
       '#title'         => t('URL menant vers votre page de politique de vie privee.'),
       '#default_value' => $defaultValues[$this->config::PRIVACY_URL],
       '#description' => 'URL interne : //mysite/{url}'
-    ];
-
-    $form[$this->config::CUSTOM_DISCLAIMER] = [
-      '#type'          => 'textfield',
-      '#title'         => t('Texte de déclaration des cookies'),
-      '#default_value' => $defaultValues[$this->config::CUSTOM_DISCLAIMER],
-      '#description' => t('Vous pouvez définir le texte invitant les visiteurs à accepter les cookies. Laisser vide pour utiliser le texte par défaut.'),
     ];
 
     $form[$this->config::HIGH_PRIVACY] = [
@@ -218,9 +218,6 @@ class TacSettingsForm extends FormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $data = $form_state->getValues();
 
-    // Modification des données "languagée".
-    $data[$this->config::ALERT_LABEL] = $this->config->get($this->config::ALERT_LABEL);
-    $data[$this->config::ALERT_LABEL][$this->languageService->getCurrentLanguageId()] = $form_state->getValue($this->config::ALERT_LABEL);
     $this->config->setAllValues($data);
 
     // Add success message.

--- a/tac_services/src/Form/TacSettingsForm.php
+++ b/tac_services/src/Form/TacSettingsForm.php
@@ -189,6 +189,15 @@ class TacSettingsForm extends FormBase {
       '#description'   => t('Afficher le message a propos des cookies obligatoires ?'),
     ];
 
+    $form[$this->config::COOKIES_DURATION] = [
+      '#type'          => 'number',
+      '#title'         => t('Durée de conservation des cookies'),
+      '#default_value' => $defaultValues[$this->config::COOKIES_DURATION],
+      '#description'   => t('Vous pouvez définir la durée (en jours) pendant lesquelle les cookies du site seront stockés sur le navigateur de l\'internaute (365 jours par defaut).'),
+      '#min'           => 1,
+      '#max'           => 365,
+    ];
+
     $form['submit'] = [
       '#type'        => 'submit',
       '#value'       => t('Save'),

--- a/tac_services/src/Service/TacGlobalConfigService.php
+++ b/tac_services/src/Service/TacGlobalConfigService.php
@@ -173,28 +173,4 @@ class TacGlobalConfigService extends ConfigServiceBase
   {
     return [];
   }
-
-  /**
-   * Retourne le libellé dans la langue courante.
-   *
-   * @params string $langCode
-   *   Le language pour lequel retourner la valeur.
-   *
-   * @return string|null
-   *   Le libelle de la langue courante si existante.
-   */
-  public function getAlertLabel($langCode = NULL)
-  {
-    if ($labels = $this->get(static::ALERT_LABEL)) {
-      $langCode = $langCode ?: $this->languageService->getCurrentLanguageId();
-      if (array_key_exists($langCode, $labels)) {
-        $label = $labels[$langCode];
-        if (!empty($label) && !empty($label['value'])) {
-          return $label;
-        }
-      }
-    }
-
-    return NULL;
-  }
 }

--- a/tac_services/src/Service/TacGlobalConfigService.php
+++ b/tac_services/src/Service/TacGlobalConfigService.php
@@ -90,12 +90,6 @@ class TacGlobalConfigService extends ConfigServiceBase
   const CUSTOM_DISCLAIMER = "custom_disclaimer";
 
   /**
-   * Libellé de l'encart d'alert.
-   */
-  const ALERT_LABEL = 'alert_label';
-
-
-  /**
    * @var LanguageService
    */
   private $languageService;
@@ -153,7 +147,6 @@ class TacGlobalConfigService extends ConfigServiceBase
       static::ADBLOCKER          => FALSE,
       static::SHOW_ALERT_SMALL   => TRUE,
       static::COOKIE_LIST        => TRUE,
-      static::ALERT_LABEL        => NULL,
       static::HANDLE_DNT_REQUEST => FALSE,
       static::MANDATORY          => TRUE,
     ];

--- a/tac_services/src/Service/TacGlobalConfigService.php
+++ b/tac_services/src/Service/TacGlobalConfigService.php
@@ -90,6 +90,11 @@ class TacGlobalConfigService extends ConfigServiceBase
   const CUSTOM_DISCLAIMER = "custom_disclaimer";
 
   /**
+   * Constant which stores the machine name of the cookies duration field name;
+   */
+  const COOKIES_DURATION = "cookies_duration";
+
+  /**
    * @var LanguageService
    */
   private $languageService;
@@ -149,6 +154,8 @@ class TacGlobalConfigService extends ConfigServiceBase
       static::COOKIE_LIST        => TRUE,
       static::HANDLE_DNT_REQUEST => FALSE,
       static::MANDATORY          => TRUE,
+      //Duration
+      static::COOKIES_DURATION   => 365,
     ];
   }
 

--- a/tac_services/tac_services.module
+++ b/tac_services/tac_services.module
@@ -79,9 +79,6 @@ function tac_services_page_attachments(array &$attachments) {
           // Icon
           $globalTacConfService::SHOW_ICON            => ($globalConfValues[$globalTacConfService::SHOW_ICON]) ? TRUE : FALSE,
           $globalTacConfService::ICON_POSITION        => $globalConfValues[$globalTacConfService::ICON_POSITION],
-
-          // Alert Label
-          $globalTacConfService::ALERT_LABEL          => $globalTacConfService->getAlertLabel(),
         ];
 
         // Ajout de la library tarte au citron.

--- a/tac_services/tac_services.module
+++ b/tac_services/tac_services.module
@@ -79,6 +79,9 @@ function tac_services_page_attachments(array &$attachments) {
           // Icon
           $globalTacConfService::SHOW_ICON            => ($globalConfValues[$globalTacConfService::SHOW_ICON]) ? TRUE : FALSE,
           $globalTacConfService::ICON_POSITION        => $globalConfValues[$globalTacConfService::ICON_POSITION],
+
+          //Cookies Duration
+          $globalTacConfService::COOKIES_DURATION     => ($globalConfValues[$globalTacConfService::COOKIES_DURATION]),
         ];
 
         // Ajout de la library tarte au citron.


### PR DESCRIPTION
- suppression de l'ancien champ wysiwyg alert_label (laissé présent mais plus utilisé)
- lien privacy policy placé entre le texte et les boutons dans la bannière + fix inté mobile
- ajout d'un champ de gestion de la durée des cookies (quand le cookie tarteaucitron expire tous les autres sont supprimés)