### PR TITLE
[RGPD] - #54696 - update module adimeo_tools to enable translation on…

### DIFF
--- a/tac_services/src/Form/TacSettingsForm.php
+++ b/tac_services/src/Form/TacSettingsForm.php
@@ -83,7 +83,7 @@ class TacSettingsForm extends FormBase {
       $form[$this->config::CUSTOM_DISCLAIMER] = [
           '#type'          => 'textarea',
           '#title'         => t('Texte de déclaration des cookies'),
-          '#default_value' => t($defaultValues[$this->config::CUSTOM_DISCLAIMER]),
+          '#default_value' => $defaultValues[$this->config::CUSTOM_DISCLAIMER],
           '#description' => t('Vous pouvez définir le texte invitant les visiteurs à accepter les cookies. Laisser vide pour utiliser le texte par défaut.'),
       ];
 

--- a/tac_services/tac_services.module
+++ b/tac_services/tac_services.module
@@ -57,7 +57,7 @@ function tac_services_page_attachments(array &$attachments) {
           // Privacy Policy URL
           $globalTacConfService::PRIVACY_URL          => $globalConfValues[$globalTacConfService::PRIVACY_URL],
 
-          $globalTacConfService::CUSTOM_DISCLAIMER    => $globalConfValues[$globalTacConfService::CUSTOM_DISCLAIMER],
+          $globalTacConfService::CUSTOM_DISCLAIMER    => t($globalConfValues[$globalTacConfService::CUSTOM_DISCLAIMER]),
 
           $globalTacConfService::HIGH_PRIVACY         => ($globalConfValues[$globalTacConfService::HIGH_PRIVACY]) ? TRUE : FALSE,
           $globalTacConfService::ALLOWED_BUTTON       => ($globalConfValues[$globalTacConfService::ALLOWED_BUTTON]) ? TRUE : FALSE,


### PR DESCRIPTION
… banner main text (rework)

Petite erreur de ma part : j'avais ouvert la traduction du message, mais c'est sur l'affichage du formulaire admin que je chargeais le texte traduit et pas sur le texte de la bannière. C'est corrigé.